### PR TITLE
feat: add sticky announcement banner for Golden Kodee Community Awards

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -167,6 +167,12 @@
       "description": "Information about how we collect, use, and protect your personal data"
     }
   },
+  "announcementBanner": {
+    "text": "I'm nominated at the Golden Kodee Community Awards in the \"In-Person Presence\" category! Vote until March 22.",
+    "textShort": "Nominated at Golden Kodee Awards!",
+    "cta": "Vote",
+    "dismiss": "Close"
+  },
   "cookieConsent": {
     "title": "🍪 Cookie Usage",
     "description": "We use cookies to analyze site traffic and improve your experience. Your data is processed anonymously.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -166,6 +166,12 @@
       "description": "Información sobre cómo recopilamos, usamos y protegemos tus datos personales"
     }
   },
+  "announcementBanner": {
+    "text": "¡Estoy nominado en los Golden Kodee Community Awards en la categoría \"In-Person Presence\"! Vota hasta el 22 de marzo.",
+    "textShort": "¡Nominado en Golden Kodee Awards!",
+    "cta": "Votar",
+    "dismiss": "Cerrar"
+  },
   "cookieConsent": {
     "title": "🍪 Uso de Cookies",
     "description": "Utilizamos cookies para analizar el tráfico del sitio y mejorar tu experiencia. Tus datos son tratados de forma anónima.",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { locales } from '@/i18n';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import CookieConsent from '@/components/CookieConsent';
+import AnnouncementBanner from '@/components/AnnouncementBanner';
 
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
@@ -35,8 +36,13 @@ export default async function LocaleLayout({
     <html lang={locale}>
       <body>
         <NextIntlClientProvider messages={messages}>
-          <Navbar />
-          {children}
+          <div className="fixed top-0 left-0 right-0 z-50">
+            <AnnouncementBanner />
+            <Navbar />
+          </div>
+          <div style={{ paddingTop: 'calc(4rem + var(--announcement-height, 2.5rem))' }}>
+            {children}
+          </div>
           <Footer />
           <CookieConsent />
         </NextIntlClientProvider>

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { X, Trophy } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+const DISMISSED_KEY = 'golden-kodee-banner-dismissed';
+const DEADLINE = new Date('2026-03-22T23:59:59');
+
+export default function AnnouncementBanner() {
+  const [isVisible, setIsVisible] = useState(false);
+  const t = useTranslations('announcementBanner');
+
+  useEffect(() => {
+    const isDismissed = localStorage.getItem(DISMISSED_KEY);
+    const isExpired = new Date() > DEADLINE;
+    if (!isDismissed && !isExpired) {
+      setIsVisible(true);
+      document.documentElement.style.setProperty('--announcement-height', '2.5rem');
+    } else {
+      document.documentElement.style.setProperty('--announcement-height', '0px');
+    }
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, 'true');
+    setIsVisible(false);
+    document.documentElement.style.setProperty('--announcement-height', '0px');
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="h-10 flex items-center px-4 bg-purple-950 border-b border-purple-800">
+      <div className="flex items-center gap-2 flex-1 justify-center min-w-0">
+        <Trophy size={14} className="text-yellow-400 shrink-0" />
+        <p className="text-xs text-purple-100 truncate">
+          <span className="hidden sm:inline">{t('text')}</span>
+          <span className="sm:hidden">{t('textShort')}</span>
+        </p>
+        <a
+          href="https://kotl.in/f273m4"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 ml-1 px-3 py-0.5 bg-purple-700 hover:bg-purple-600 text-white text-xs font-semibold rounded-full transition-colors duration-200"
+        >
+          {t('cta')}
+        </a>
+      </div>
+      <button
+        onClick={dismiss}
+        aria-label={t('dismiss')}
+        className="shrink-0 ml-2 text-purple-400 hover:text-white transition-colors duration-200"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -26,7 +26,7 @@ export default function HeroSection() {
 
   if (!mounted) {
     return (
-      <section className="min-h-screen flex items-center justify-center px-4 pt-16 relative">
+      <section className="min-h-screen flex items-center justify-center px-4 relative">
         <div className="max-w-4xl mx-auto text-center">
           <div className="mb-8">
             <div className="w-32 h-32 md:w-40 md:h-40 mx-auto rounded-full bg-gradient-to-br from-accent-blue to-accent-yellow p-1">
@@ -47,7 +47,7 @@ export default function HeroSection() {
   }
 
   return (
-    <section className="min-h-screen flex items-center justify-center px-4 pt-16 relative">
+    <section className="min-h-screen flex items-center justify-center px-4 relative">
       <div className="max-w-6xl mx-auto w-full">
         <div className="flex flex-col md:flex-row items-center justify-center gap-8 md:gap-16">
           {/* Avatar - Left Side */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -43,7 +43,7 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-white/95 dark:bg-[#0b0f19]/95 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800 transition-colors duration-300">
+    <nav className="bg-white/95 dark:bg-[#0b0f19]/95 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800 transition-colors duration-300">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}


### PR DESCRIPTION
## Summary

- Add `AnnouncementBanner` component with purple Kotlin-brand styling above the navbar
- Banner invites visitors to vote in the **Golden Kodee Community Awards** — "In-Person Presence" category (vote link: kotl.in/f273m4)
- Auto-expires on March 22, 2026 — no manual cleanup needed

## Changes

- **New**: `src/components/AnnouncementBanner.tsx` — dismissible banner with localStorage persistence, bilingual (ES/EN), responsive (short text on mobile)
- **Modified**: `src/app/[locale]/layout.tsx` — wraps banner + navbar in a single `fixed` container; adds dynamic `paddingTop` via CSS variable `--announcement-height`
- **Modified**: `src/components/Navbar.tsx` — removed own `fixed` positioning (now handled by parent wrapper)
- **Modified**: `src/components/HeroSection.tsx` — removed `pt-16` (now handled by layout wrapper)
- **Modified**: `messages/es.json` + `messages/en.json` — added `announcementBanner` translation keys

## Test plan

- [ ] Banner appears at top of page in purple/dark styling with trophy icon and "Votar/Vote" button
- [ ] Vote button opens `kotl.in/f273m4` in a new tab
- [ ] X button dismisses the banner and it doesn't reappear on reload
- [ ] Resetting `golden-kodee-banner-dismissed` from localStorage brings it back
- [ ] Language toggle switches banner text to EN/ES correctly
- [ ] Mobile view shows short text variant; desktop shows full text
- [ ] Content on all pages (`/`, `/contact`, `/privacy`) is not hidden behind the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)